### PR TITLE
Fix code demo adress on the course page

### DIFF
--- a/vignettes/get_demo_data.R
+++ b/vignettes/get_demo_data.R
@@ -24,10 +24,8 @@ rmds_link <- paste0("../code-demos/code_demo_", demos, ".Rmd")
 cddat$Rmd <- paste0(
   "[Rmd](https://github.com/compstat-lmu/lecture_i2ml/tree/master/code-demos/code_demo_", 
   demos, ".Rmd)")
-cddat$PDF <- paste0("[pdf](https://nbviewer.jupyter.org/github/compstat-lmu/lecture_i2ml/blob/master/code-demo-pdf/code_demo_", 
+cddat$PDF <- paste0("[pdf](https://nbviewer.jupyter.org/github/compstat-lmu/lecture_i2ml/tree/master/code-demos-pdf/code_demo_", 
                     demos, ".pdf)")
-
-
 
 ## Read the title lines from the files
 lns <- lapply(rmds_link, readLines, n = 7)


### PR DESCRIPTION
Fixes broken links to the code demos on the course page